### PR TITLE
Optimize dataframe and operation caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -512,7 +512,7 @@ opts = {
 
 with c1000.beta_container():
     #st_echarts(opts, width = 1500, height= 400)
-    st_echarts(opts, width = 1600, height= 375)
+    st_echarts(opts, width = 1600, height= 375, key="chart")
 
 #region multiselect ############################################################
 


### PR DESCRIPTION
Optimize app caching. The strategy here is to compute as much data as possible based on both text area values (Box #01 and Box #02),

Changes:
- Used constants for column names
- Renamed lineDeduped to lineDeduped1
- Removed caching of functions `ratio`, `partial_ratio`, `token_sort_ratio` and `token_set_ratio` (it seemed to perform faster without caching, but that must be verified...)
- Gathered all dataframe operations inside one cached function: `prepareDF`, which returns a dict with every info needed for the rest of the app
- Changed how DataFrames were copied (used `pd.DataFrame` instead of copying the whole dfRatio and dropping columns)
- Do not copy dfFiltered from dfRatio, as no mutable operation is done on the DataFrame now
- Put the slider part in a generic `filter_if()` function
- Add a key to echarts to avoid redrawing when toggling a token checkbox

Note that I haven't updated your Todos/Fixed tasks.